### PR TITLE
swap md set to update, fix md delete bug

### DIFF
--- a/ibridgesgui/ui_files/tabBrowser.py
+++ b/ibridgesgui/ui_files/tabBrowser.py
@@ -405,7 +405,7 @@ class Ui_tabBrowser(object):
         self.delete_meta_button.setText(_translate("tabBrowser", "Delete"))
         self.label_4.setText(_translate("tabBrowser", "Key"))
         self.label_3.setText(_translate("tabBrowser", "Edit"))
-        self.update_meta_button.setText(_translate("tabBrowser", "Set all keys .."))
+        self.update_meta_button.setText(_translate("tabBrowser", "Update"))
         self.label_6.setText(_translate("tabBrowser", "Value"))
         self.info_tabs.setTabText(self.info_tabs.indexOf(self.metadata), _translate("tabBrowser", "Metadata"))
         self.info_tabs.setTabText(self.info_tabs.indexOf(self.preview), _translate("tabBrowser", "Preview"))

--- a/ibridgesgui/ui_files/tabBrowser.ui
+++ b/ibridgesgui/ui_files/tabBrowser.ui
@@ -444,7 +444,7 @@ QTabWidget#info_tabs
             </font>
            </property>
            <property name="text">
-            <string>Set all keys ..</string>
+            <string>Update</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The browser has now a real Metadata update button which exchanges the selected metadata with the values provided in the text fields.

Unfortunately I could not. make use of our new coll backend functionality, since there you can only change one item of the metadata triple at a time. The GUI asks all information at on time point. But adding those changes subsequently can lead to hitting already existing metadata. So I implemented an own function which should do the trick.

All feedback is welcome.
