### PR TITLE
bugfix class names in ui files

### DIFF
--- a/ibridgesgui/ui_files/configCheck.ui
+++ b/ibridgesgui/ui_files/configCheck.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>configCheck</class>
+ <widget class="QDialog" name="configCheck">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/ibridgesgui/ui_files/downloadData.ui
+++ b/ibridgesgui/ui_files/downloadData.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>downloadData</class>
+ <widget class="QWidget" name="downloadData">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/ibridgesgui/ui_files/tabLogging.ui
+++ b/ibridgesgui/ui_files/tabLogging.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>tabLogging</class>
+ <widget class="QWidget" name="tabLogging">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/ibridgesgui/ui_files/transferData.ui
+++ b/ibridgesgui/ui_files/transferData.ui
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>transferData</class>
+ <widget class="QWidget" name="transferData">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>936</width>
+    <width>973</width>
     <height>395</height>
    </rect>
   </property>
@@ -84,6 +84,7 @@ QTabWidget#info_tabs
        <property name="font">
         <font>
          <pointsize>16</pointsize>
+         <weight>50</weight>
          <italic>false</italic>
          <bold>false</bold>
         </font>
@@ -115,6 +116,7 @@ ibridges_metadata.json</string>
      <property name="font">
       <font>
        <pointsize>16</pointsize>
+       <weight>50</weight>
        <italic>false</italic>
        <bold>false</bold>
       </font>
@@ -168,7 +170,7 @@ ibridges_metadata.json</string>
    <item row="1" column="3">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>                                                              </string>
+      <string/>
      </property>
     </widget>
    </item>

--- a/ibridgesgui/ui_files/uploadData.ui
+++ b/ibridgesgui/ui_files/uploadData.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>uploadData</class>
+ <widget class="QWidget" name="uploadData">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/ibridgesgui/ui_files/welcome.ui
+++ b/ibridgesgui/ui_files/welcome.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
+ <class>Welcome</class>
+ <widget class="QWidget" name="Welcome">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Heey,

Somewhere in the editing process the class names of the Ui files have been removed.
To my surprise they are correct in the '.py' files, no clue what went wrong there but it's an easy fix.

Hope we can get this merged soon (I am compiling executables and this breaks everything)