### PR TITLE
Harmonise cli and gui cached passwords

### DIFF
--- a/ibridgesgui/popup_widgets.py
+++ b/ibridgesgui/popup_widgets.py
@@ -14,7 +14,6 @@ from ibridges import IrodsPath, download, upload
 from ibridges.exception import DataObjectExistsError
 from ibridges.util import find_environment_provider, get_environment_providers
 
-# from PyQt6.QtWidgets import QDialog, QFileDialog, QMessageBox
 from ibridgesgui.config import _read_json, check_irods_config, get_last_ienv_path, save_irods_config
 from ibridgesgui.gui_utils import UI_FILE_DIR, combine_operations, load_ui, populate_textfield
 from ibridgesgui.threads import TransferDataThread


### PR DESCRIPTION
The GUI login is extended such that:

- look up all environment files mentioned in the cli config
- if file is not listed or not listed with a password, add to previous gui settings
- only do so if cli config mentions a cached password

In that way the GUI config is leading and the CLI config is used to add, if not defined.