### PR TITLE
deprecate ibridges-gui in favour of 'ibridges gui'

### DIFF
--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -6,7 +6,6 @@ import os
 import sys
 from functools import partial
 from pathlib import Path
-import warnings
 
 import PySide6.QtGui
 import PySide6.QtUiTools

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -307,10 +307,8 @@ def main():
 def main_deprecated():
     """Deprecate the ibridges-gui call."""
     logger = logging.getLogger(THIS_APPLICATION)
-    logger.info(
-        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher")
-    print(
-        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher")
+    logger.warn(
+        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher.")
 
 if __name__ == "__main__":
     main()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -307,7 +307,7 @@ def main_deprecated():
     """Deprecate the ibridges-gui call."""
     logger = logging.getLogger(THIS_APPLICATION)
     logger.warning(
-        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher.")
+        "The command 'ibridges-gui' will be deprecated in iBridges 2.0. Use 'ibridges gui' instead.")
 
 if __name__ == "__main__":
     main()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -302,5 +302,10 @@ def main():
     app.exec()
 
 
-if __name__ == "__main__":
+def main_deprecated():
+    """Deprecate the ibridges-gui call."""
+    print("'ibridges-gui' will be deprecated. Please use 'ibridges gui' from ibridges 1.5.1")
     main()
+
+if __name__ == "__main__":
+    main_deprecated()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -307,7 +307,7 @@ def main_deprecated():
     """Deprecate the ibridges-gui call."""
     logger = logging.getLogger(THIS_APPLICATION)
     logger.warning(
-        "The command 'ibridges-gui' will be deprecated in iBridges 2.0. Use 'ibridges gui' instead.")
+        "The command 'ibridges-gui' will be deprecated in iBridges 2.0. Use 'ibridges gui' instead.") # noqa: E501
 
 if __name__ == "__main__":
     main()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -307,7 +307,7 @@ def main_deprecated():
     """Deprecate the ibridges-gui call."""
     logger = logging.getLogger(THIS_APPLICATION)
     logger.warning(
-        "The command 'ibridges-gui' will be deprecated in iBridges 2.0. Use 'ibridges gui' instead.") # noqa: E501
+        "The command 'ibridges-gui' will be deprecated in iBridges 2.0. Use 'ibridges gui' instead.") # noqa: E501 # pylint: disable=C0301
 
 if __name__ == "__main__":
     main()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -6,6 +6,7 @@ import os
 import sys
 from functools import partial
 from pathlib import Path
+import warnings
 
 import PySide6.QtGui
 import PySide6.QtUiTools
@@ -58,7 +59,6 @@ class MainMenu(PySide6.QtWidgets.QMainWindow, Ui_MainWindow):
         app.aboutToQuit.connect(self.close_event)
 
         self.logger = logging.getLogger(app_name)
-
         self.irods_path = Path("~", ".irods").expanduser()
         self.app_name = app_name
         self.welcome_tab()
@@ -292,6 +292,8 @@ def main():
         set_log_level("debug")
         init_logger(THIS_APPLICATION, "debug")
 
+    main_deprecated()
+
     # Set the working directory to the directory of the current file
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     ensure_irods_location()
@@ -304,8 +306,11 @@ def main():
 
 def main_deprecated():
     """Deprecate the ibridges-gui call."""
-    print("'ibridges-gui' will be deprecated. Please use 'ibridges gui' from ibridges 1.5.1")
-    main()
+    logger = logging.getLogger(THIS_APPLICATION)
+    logger.info(
+        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher")
+    print(
+        "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher")
 
 if __name__ == "__main__":
-    main_deprecated()
+    main()

--- a/ibridgesgui/__main__.py
+++ b/ibridgesgui/__main__.py
@@ -306,7 +306,7 @@ def main():
 def main_deprecated():
     """Deprecate the ibridges-gui call."""
     logger = logging.getLogger(THIS_APPLICATION)
-    logger.warn(
+    logger.warning(
         "'ibridges-gui' will be deprecated. Use 'ibridges gui', needs ibridges 1.5.1 or higher.")
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ all = [
 ]
 
 [project.scripts]
-ibridges-gui = "ibridgesgui.__main__:main_deprecated"
+ibridges-gui = "ibridgesgui.__main__:main"
 
 [tool.setuptools]
 packages = ["ibridgesgui"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ all = [
 ]
 
 [project.scripts]
-ibridges-gui = "ibridgesgui.__main__:main"
+ibridges-gui = "ibridgesgui.__main__:main_deprecated"
 
 [tool.setuptools]
 packages = ["ibridgesgui"]


### PR DESCRIPTION
From ibridges 1.5.1 (next bugfix release) one can start the GUI with the ibridges commandline tool by simply typing in

```
ibridges gui
```

This PR just contains the deprecation notice.